### PR TITLE
fix(ci): add packagist update back and adjust code coverage settings

### DIFF
--- a/.github/workflows/create-coverage-report.yml
+++ b/.github/workflows/create-coverage-report.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - "src/**.php"
       - "tests/**.php"
+      - "codecov.yml"
+      - ".github/workflows/create-coverage-report.yml"
     tags-ignore:
       - "**"
   pull_request:
@@ -15,6 +17,8 @@ on:
     paths:
       - "src/**.php"
       - "tests/**.php"
+      - "codecov.yml"
+      - ".github/workflows/create-coverage-report.yml"
   workflow_dispatch:
 
 jobs:
@@ -41,6 +45,7 @@ jobs:
         uses: php-actions/phpunit@v3
         env:
           XDEBUG_MODE: coverage
+          POSTGREST_VERSION: "11"
         with:
           php_extensions: "xdebug"
           coverage_clover: "coverage.xml"

--- a/.github/workflows/update-packagist.yml
+++ b/.github/workflows/update-packagist.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "master"
+    tags-ignore:
+      - "**"
   release:
 
 jobs:

--- a/.github/workflows/update-packagist.yml
+++ b/.github/workflows/update-packagist.yml
@@ -1,6 +1,6 @@
 name: Update Packagist
 
-on: [release]
+on: [push, release]
 
 jobs:
   packagist:
@@ -9,8 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Update Packagist
-        run: echo FIXME
-      # - uses: mnavarrocarter/packagist-update@v1.0
-      #   with:
-      #     username: "campoint"
-      #     api_token: ${{ secrets.packagist_token }}
+        uses: mnavarrocarter/packagist-update@v1.0
+        with:
+          username: "campoint"
+          api_token: ${{ secrets.PACKAGIST_TOKEN }}

--- a/.github/workflows/update-packagist.yml
+++ b/.github/workflows/update-packagist.yml
@@ -1,6 +1,10 @@
 name: Update Packagist
 
-on: [push, release]
+on:
+  push:
+    branches:
+      - "master"
+  release:
 
 jobs:
   packagist:

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 93%
+        target: 90%
         threshold: 1%
 
 comment:


### PR DESCRIPTION
Add Packagist update back after the API key was added a repo secret.
Adjust codecov target value to 90% and add env var to report creation denoting the PostgREST version running.